### PR TITLE
feat : owner auth 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,20 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/odiga/common/entity/BaseEntity.java
+++ b/src/main/java/com/odiga/common/entity/BaseEntity.java
@@ -1,23 +1,23 @@
 package com.odiga.common.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
-
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-	@CreatedDate
-	@Column(updatable = false)
-	private LocalDateTime createdAt;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
-	@LastModifiedDate
-	private LocalDateTime updateAt;
+    @LastModifiedDate
+    private LocalDateTime updateAt;
 }

--- a/src/main/java/com/odiga/common/type/Role.java
+++ b/src/main/java/com/odiga/common/type/Role.java
@@ -1,0 +1,6 @@
+package com.odiga.common.type;
+
+public enum Role {
+    ROLE_USER, ROLE_OWNER;
+
+}

--- a/src/main/java/com/odiga/global/config/SecurityConfig.java
+++ b/src/main/java/com/odiga/global/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.odiga.global.filter.JwtExceptionFilter;
 import com.odiga.global.jwt.JwtTokenProvider;
 import com.odiga.owner.application.OwnerUserDetailsService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -33,7 +32,6 @@ public class SecurityConfig {
 
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/owners/auth/**").permitAll()
-                .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .anyRequest().authenticated()
             )
             .headers(header -> header.frameOptions(FrameOptionsConfig::sameOrigin))

--- a/src/main/java/com/odiga/global/config/SecurityConfig.java
+++ b/src/main/java/com/odiga/global/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.odiga.global.config;
+
+import com.odiga.global.filter.JwtAuthenticationFilter;
+import com.odiga.global.filter.JwtExceptionFilter;
+import com.odiga.global.jwt.JwtTokenProvider;
+import com.odiga.owner.application.OwnerUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final OwnerUserDetailsService ownerUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain ownerFilterChain(HttpSecurity http) throws Exception {
+        http.securityMatcher("api/v1/owners/**")
+
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/owners/auth/**").permitAll()
+                .requestMatchers(PathRequest.toH2Console()).permitAll()
+                .anyRequest().authenticated()
+            )
+            .headers(header -> header.frameOptions(FrameOptionsConfig::sameOrigin))
+
+            .httpBasic(HttpBasicConfigurer::disable)
+            .csrf(CsrfConfigurer::disable)
+
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // session 을 사용하지 않음
+            )
+
+            .userDetailsService(ownerUserDetailsService)
+            .addFilterBefore(new JwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/odiga/global/config/SwaggerConfig.java
+++ b/src/main/java/com/odiga/global/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.odiga.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "O-DI-GA",
+        description = "O-DI-GA API 명세서.",
+        version = "v1")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi openApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+            .group("O-DI-GA v1")
+            .pathsToMatch(paths)
+            .build();
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+            .in(SecurityScheme.In.HEADER).name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+            .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+            .security(Arrays.asList(securityRequirement));
+    }
+
+}

--- a/src/main/java/com/odiga/global/config/SwaggerConfig.java
+++ b/src/main/java/com/odiga/global/config/SwaggerConfig.java
@@ -21,7 +21,7 @@ public class SwaggerConfig {
 
     @Bean
     public GroupedOpenApi openApi() {
-        String[] paths = {"/**"};
+        String[] paths = {"/api/v1/**"};
 
         return GroupedOpenApi.builder()
             .group("O-DI-GA v1")

--- a/src/main/java/com/odiga/global/exception/CustomException.java
+++ b/src/main/java/com/odiga/global/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.odiga.global.exception;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/odiga/global/exception/ErrorCode.java
+++ b/src/main/java/com/odiga/global/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.odiga.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+}

--- a/src/main/java/com/odiga/global/exception/ErrorResponse.java
+++ b/src/main/java/com/odiga/global/exception/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.odiga.global.exception;
+
+public record ErrorResponse(String message) {
+
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/com/odiga/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/odiga/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.odiga.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customExceptionHandler(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        
+        return ResponseEntity.status(errorCode.getHttpStatus())
+            .body(ErrorResponse.of(errorCode.getMessage()));
+    }
+
+}

--- a/src/main/java/com/odiga/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/odiga/global/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.odiga.global.filter;
+
+import com.odiga.global.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+                         FilterChain filterChain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        String accessToken = resolveToken(request);
+
+        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateToken(accessToken)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest servletRequest) {
+        String bearerToken = servletRequest.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/odiga/global/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/odiga/global/filter/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.odiga.global.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.odiga.global.exception.CustomException;
+import com.odiga.global.exception.ErrorCode;
+import com.odiga.global.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            sendErrorResponse(response, e.getErrorCode());
+        }
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+        throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.getWriter().write(new ObjectMapper().writeValueAsString(ErrorResponse.of(errorCode.getMessage())));
+        response.getWriter().flush();
+        response.getWriter().close();
+    }
+}

--- a/src/main/java/com/odiga/global/jwt/JwtErrorCode.java
+++ b/src/main/java/com/odiga/global/jwt/JwtErrorCode.java
@@ -1,0 +1,27 @@
+package com.odiga.global.jwt;
+
+import com.odiga.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+
+    EXPIRE_ERROR(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰 입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 형식의 토큰 입니다."),
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/odiga/global/jwt/JwtTokenDto.java
+++ b/src/main/java/com/odiga/global/jwt/JwtTokenDto.java
@@ -1,0 +1,9 @@
+package com.odiga.global.jwt;
+
+public record JwtTokenDto(String accessToken, String refreshToken) {
+
+    public static JwtTokenDto of(String accessToken, String refreshToken) {
+        return new JwtTokenDto(accessToken, refreshToken);
+    }
+
+}

--- a/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
@@ -1,10 +1,15 @@
 package com.odiga.global.jwt;
 
+import com.odiga.global.exception.CustomException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
@@ -69,9 +74,14 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (Exception e) {
-            // TODO : 추가적인 exception 분기 필요
-            throw new RuntimeException(e);
+        } catch (SignatureException | MalformedJwtException e) {
+            throw new CustomException(JwtErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(JwtErrorCode.EXPIRE_ERROR);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(JwtErrorCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(JwtErrorCode.NOT_FOUND_TOKEN);
         }
     }
 }

--- a/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
@@ -64,4 +64,14 @@ public class JwtTokenProvider {
             .parseClaimsJws(token)
             .getBody();
     }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            // TODO : 추가적인 exception 분기 필요
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/odiga/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.odiga.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final long tokenExpireSeconds;
+    private final Key key;
+    private final UserDetailsService userDetailsService;
+
+    public JwtTokenProvider(@Value("${security.jwt.secret}") String secretKey,
+                            @Value("${security.jwt.expire-seconds}") long tokenExpireSeconds,
+                            UserDetailsService userDetailsService) {
+        this.tokenExpireSeconds = tokenExpireSeconds;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.userDetailsService = userDetailsService;
+    }
+
+    public JwtTokenDto createToken(String email) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpireTime = new Date(now + tokenExpireSeconds);
+        Date refreshTokenExpireTime = new Date(now + (tokenExpireSeconds * 2 * 30));
+
+        String accessToken = Jwts.builder()
+            .setSubject(email)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(accessTokenExpireTime)
+            .compact();
+
+        String refreshToken = Jwts.builder()
+            .setSubject(email)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(refreshTokenExpireTime)
+            .compact();
+
+        return JwtTokenDto.of(accessToken, refreshToken);
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = getClaims(token).getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts
+            .parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+}

--- a/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
+++ b/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
@@ -38,13 +38,13 @@ public interface OwnerAuthApi {
                   "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQGdtYWlsLmNvbSIsImV4cCI6MTc0MjkxNzA0MH0.CTP03FkIwQ53jyBezXEM4pxtQoiBtoglW-3Da0q65xoa-Qzjvsqw5q9Pp31e2SJ_xtEzbkCLOh6qqkpBy0BakQ"
                 }
                 """),})),
-        @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "로그인 실패 - 존재하지 않는 email", value = """
                 {
                   "message": "존재하지 않는 계정입니다."
                 }
                 """),})),
-        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+        @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "로그인 실패 - 옳바르지 않은 비밀번호", value = """
                 {
                   "message": "올바르지 않은 비밀번호 입니다."

--- a/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
+++ b/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
@@ -1,0 +1,55 @@
+package com.odiga.owner.api;
+
+import com.odiga.owner.dto.OwnerLoginRequestDto;
+import com.odiga.owner.dto.OwnerSignupRequestDto;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Owner Auth API", description = "Owner 회원 관련 API")
+public interface OwnerAuthApi {
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "회원가입 성공", value = """
+                {
+                  "id": 1,
+                  "email": "example@gmail.com",
+                  "name": "홍길동"
+                }
+                """),})),
+        @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "회원가입 실패 - 이미 존재하는 email", value = """
+                {
+                  "message": "이미 존재하는 email 입니다."
+                }
+                """)}))})
+    ResponseEntity<?> ownerSignup(@RequestBody OwnerSignupRequestDto ownerSignupRequestDto);
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "로그인 성공", value = """
+                {
+                  "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQGdtYWlsLmNvbSIsImV4cCI6MTc0MjkxNDQ5Mn0.xBpNreQDdR_595Ap1oTDmUmJXCKB-HATRyvtUSUC-jwQVcI-ZmoG9wpi8y4xJOzIi00m2yKIkvsmNzkOeOf9DQ",
+                  "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQGdtYWlsLmNvbSIsImV4cCI6MTc0MjkxNzA0MH0.CTP03FkIwQ53jyBezXEM4pxtQoiBtoglW-3Da0q65xoa-Qzjvsqw5q9Pp31e2SJ_xtEzbkCLOh6qqkpBy0BakQ"
+                }
+                """),})),
+        @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "로그인 실패 - 존재하지 않는 email", value = """
+                {
+                  "message": "존재하지 않는 계정입니다."
+                }
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "로그인 실패 - 옳바르지 않은 비밀번호", value = """
+                {
+                  "message": "올바르지 않은 비밀번호 입니다."
+                }
+                """)}))})
+    ResponseEntity<?> ownerLogin(@RequestBody OwnerLoginRequestDto ownerLoginRequestDto);
+
+}

--- a/src/main/java/com/odiga/owner/application/OwnerAuthService.java
+++ b/src/main/java/com/odiga/owner/application/OwnerAuthService.java
@@ -1,0 +1,55 @@
+package com.odiga.owner.application;
+
+import com.odiga.global.exception.CustomException;
+import com.odiga.global.jwt.JwtTokenDto;
+import com.odiga.global.jwt.JwtTokenProvider;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.dto.OwnerInfoResponseDto;
+import com.odiga.owner.dto.OwnerLoginRequestDto;
+import com.odiga.owner.dto.OwnerSignupRequestDto;
+import com.odiga.owner.entity.Owner;
+import com.odiga.owner.exception.OwnerErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerAuthService {
+
+    private final OwnerRepository ownerRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public OwnerInfoResponseDto signupOwner(OwnerSignupRequestDto ownerSignupRequestDto) {
+        if (ownerRepository.existsByEmail(ownerSignupRequestDto.email())) {
+            throw new CustomException(OwnerErrorCode.EMAIL_CONFLICT);
+        }
+
+        Owner owner = Owner.builder()
+            .name(ownerSignupRequestDto.name())
+            .email(ownerSignupRequestDto.email())
+            .password(passwordEncoder.encode(ownerSignupRequestDto.password()))
+            .build();
+
+        ownerRepository.save(owner);
+
+        return OwnerInfoResponseDto.from(owner);
+    }
+
+    @Transactional(readOnly = true)
+    public JwtTokenDto loginOwner(OwnerLoginRequestDto ownerLoginRequestDto) {
+
+        Owner owner = ownerRepository.findByEmail(ownerLoginRequestDto.email())
+            .orElseThrow(() -> new CustomException(OwnerErrorCode.NOT_FOUND));
+
+        if (!passwordEncoder.matches(ownerLoginRequestDto.password(), owner.getPassword())) {
+            throw new CustomException(OwnerErrorCode.INCORRECT_PASSWORD);
+        }
+
+        return jwtTokenProvider.createToken(owner.getEmail());
+    }
+
+}

--- a/src/main/java/com/odiga/owner/application/OwnerUserDetailsService.java
+++ b/src/main/java/com/odiga/owner/application/OwnerUserDetailsService.java
@@ -1,8 +1,8 @@
 package com.odiga.owner.application;
 
 import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -14,7 +14,7 @@ public class OwnerUserDetailsService implements UserDetailsService {
     private final OwnerRepository ownerRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public Owner loadUserByUsername(String username) throws UsernameNotFoundException {
         return ownerRepository.findByEmail(username)
             .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 email 입니다."));
     }

--- a/src/main/java/com/odiga/owner/application/OwnerUserDetailsService.java
+++ b/src/main/java/com/odiga/owner/application/OwnerUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.odiga.owner.application;
+
+import com.odiga.owner.dao.OwnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerUserDetailsService implements UserDetailsService {
+
+    private final OwnerRepository ownerRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return ownerRepository.findByEmail(username)
+            .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 email 입니다."));
+    }
+}

--- a/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
+++ b/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
@@ -1,0 +1,34 @@
+package com.odiga.owner.controller;
+
+import com.odiga.owner.application.OwnerAuthService;
+import com.odiga.owner.dto.OwnerLoginRequestDto;
+import com.odiga.owner.dto.OwnerSignupRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/v1/owners/auth")
+public class OwnerAuthController {
+
+    private final OwnerAuthService ownerAuthService;
+
+    @PostMapping("signup")
+    public ResponseEntity<?> ownerSignup(@RequestBody OwnerSignupRequestDto ownerSignupRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ownerAuthService.signupOwner(ownerSignupRequestDto));
+    }
+
+
+    @PostMapping("login")
+    public ResponseEntity<?> ownerLogin(@RequestBody OwnerLoginRequestDto ownerLoginRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ownerAuthService.loginOwner(ownerLoginRequestDto));
+    }
+
+}

--- a/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
+++ b/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
@@ -1,5 +1,6 @@
 package com.odiga.owner.controller;
 
+import com.odiga.owner.api.OwnerAuthApi;
 import com.odiga.owner.application.OwnerAuthService;
 import com.odiga.owner.dto.OwnerLoginRequestDto;
 import com.odiga.owner.dto.OwnerSignupRequestDto;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/v1/owners/auth")
-public class OwnerAuthController {
+public class OwnerAuthController implements OwnerAuthApi {
 
     private final OwnerAuthService ownerAuthService;
 

--- a/src/main/java/com/odiga/owner/dao/OwnerRepository.java
+++ b/src/main/java/com/odiga/owner/dao/OwnerRepository.java
@@ -1,0 +1,11 @@
+package com.odiga.owner.dao;
+
+import com.odiga.owner.entity.Owner;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+
+    Optional<Owner> findByEmail(String email);
+
+}

--- a/src/main/java/com/odiga/owner/dao/OwnerRepository.java
+++ b/src/main/java/com/odiga/owner/dao/OwnerRepository.java
@@ -8,4 +8,5 @@ public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
     Optional<Owner> findByEmail(String email);
 
+    boolean existsByEmail(String mail);
 }

--- a/src/main/java/com/odiga/owner/dto/OwnerInfoResponseDto.java
+++ b/src/main/java/com/odiga/owner/dto/OwnerInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.odiga.owner.dto;
+
+import com.odiga.owner.entity.Owner;
+import lombok.Builder;
+
+@Builder
+public record OwnerInfoResponseDto(Long id, String email, String name) {
+
+    public static OwnerInfoResponseDto from(Owner owner) {
+        return OwnerInfoResponseDto.builder()
+            .id(owner.getId())
+            .email(owner.getEmail())
+            .name(owner.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/odiga/owner/dto/OwnerLoginRequestDto.java
+++ b/src/main/java/com/odiga/owner/dto/OwnerLoginRequestDto.java
@@ -1,5 +1,12 @@
 package com.odiga.owner.dto;
 
-public record OwnerLoginRequestDto(String email, String password) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "Owner 로그인 요청")
+public record OwnerLoginRequestDto(
+    @Schema(description = "Owner 사용자 이메일", example = "example@gmail.com")
+    String email,
+    @Schema(description = "Owner 사용자 비밀번호", example = "ExamplePassword123@")
+    String password) {
 
 }

--- a/src/main/java/com/odiga/owner/dto/OwnerLoginRequestDto.java
+++ b/src/main/java/com/odiga/owner/dto/OwnerLoginRequestDto.java
@@ -1,0 +1,5 @@
+package com.odiga.owner.dto;
+
+public record OwnerLoginRequestDto(String email, String password) {
+
+}

--- a/src/main/java/com/odiga/owner/dto/OwnerSignupRequestDto.java
+++ b/src/main/java/com/odiga/owner/dto/OwnerSignupRequestDto.java
@@ -1,5 +1,15 @@
 package com.odiga.owner.dto;
 
-public record OwnerSignupRequestDto(String email, String password, String name) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "Owner 회원가입 요청")
+public record OwnerSignupRequestDto(
+
+    @Schema(description = "Owner 사용자 이메일", example = "example@gmail.com")
+    String email,
+    @Schema(description = "Owner 사용자 비밀번호", example = "ExamplePassword123@")
+    String password,
+    @Schema(description = "Owner 사용자 이름", example = "홍길동")
+    String name) {
 
 }

--- a/src/main/java/com/odiga/owner/dto/OwnerSignupRequestDto.java
+++ b/src/main/java/com/odiga/owner/dto/OwnerSignupRequestDto.java
@@ -1,0 +1,5 @@
+package com.odiga.owner.dto;
+
+public record OwnerSignupRequestDto(String email, String password, String name) {
+
+}

--- a/src/main/java/com/odiga/owner/entity/Owner.java
+++ b/src/main/java/com/odiga/owner/entity/Owner.java
@@ -1,6 +1,7 @@
 package com.odiga.owner.entity;
 
 import com.odiga.common.entity.BaseEntity;
+import com.odiga.common.type.Role;
 import com.odiga.store.entity.Store;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -10,18 +11,23 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Owner extends BaseEntity {
+public class Owner extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,5 +47,15 @@ public class Owner extends BaseEntity {
     public void addStore(Store store) {
         stores.add(store);
         store.setOwner(this);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(Role.ROLE_OWNER.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
     }
 }

--- a/src/main/java/com/odiga/owner/entity/Owner.java
+++ b/src/main/java/com/odiga/owner/entity/Owner.java
@@ -1,17 +1,16 @@
 package com.odiga.owner.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.odiga.common.entity.BaseEntity;
 import com.odiga.store.entity.Store;
-
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,22 +23,23 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Owner extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private String email;
+    @Column(unique = true, nullable = false)
+    private String email;
 
-	private String password;
+    private String password;
 
-	private String name;
+    private String name;
 
-	@Builder.Default
-	@OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
-	private List<Store> stores = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
+    private List<Store> stores = new ArrayList<>();
 
-	public void addStore(Store store) {
-		stores.add(store);
-		store.setOwner(this);
-	}
+    public void addStore(Store store) {
+        stores.add(store);
+        store.setOwner(this);
+    }
 }

--- a/src/main/java/com/odiga/owner/exception/OwnerErrorCode.java
+++ b/src/main/java/com/odiga/owner/exception/OwnerErrorCode.java
@@ -17,11 +17,11 @@ public enum OwnerErrorCode implements ErrorCode {
 
     @Override
     public HttpStatus getHttpStatus() {
-        return null;
+        return httpStatus;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/src/main/java/com/odiga/owner/exception/OwnerErrorCode.java
+++ b/src/main/java/com/odiga/owner/exception/OwnerErrorCode.java
@@ -1,0 +1,27 @@
+package com.odiga.owner.exception;
+
+import com.odiga.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum OwnerErrorCode implements ErrorCode {
+
+    EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 email 입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "올바르지 않은 비밀번호 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/src/main/java/com/odiga/user/entity/User.java
+++ b/src/main/java/com/odiga/user/entity/User.java
@@ -7,10 +7,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "Users")
 public class User extends BaseEntity {
 
     @Id

--- a/src/test/java/com/odiga/config/TestConfig.java
+++ b/src/test/java/com/odiga/config/TestConfig.java
@@ -1,0 +1,14 @@
+package com.odiga.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Bean
+    public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
+        return new HandlerMappingIntrospector();
+    }
+}

--- a/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,87 @@
+package com.odiga.global.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.odiga.common.type.Role;
+import com.odiga.owner.application.OwnerUserDetailsService;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class JwtTokenProviderTest {
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    OwnerUserDetailsService ownerUserDetailsService;
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    Owner owner;
+
+    @BeforeEach
+    void init() {
+        String secretKey = "secretKeySecretKeySecretKeySecretKeySecretKeysecretKeySecretKeySecretKeySecretKeySecretKey";
+        jwtTokenProvider = new JwtTokenProvider(secretKey, 1000, ownerUserDetailsService);
+        owner = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .build();
+    }
+
+    @Test
+    void creatTokenTest() {
+        JwtTokenDto token = jwtTokenProvider.createToken("example@google.com");
+
+        assertThat(token.accessToken()).isNotNull();
+        assertThat(token.refreshToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("유효 기간이 지난 access token의 claims 조회한 경우 예외를 발생")
+    void expireTimeTest() throws InterruptedException {
+        JwtTokenDto token = jwtTokenProvider.createToken("example@google.com");
+        Thread.sleep(2000);
+
+        assertThatThrownBy(() -> jwtTokenProvider.getClaims(token.accessToken())).isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    @DisplayName("올바른 Owner email으로 authentication을 조회하면 OWNER 권한을 가진다")
+    void getOwnerAuthenticationTest() {
+
+        ownerRepository.save(owner);
+
+        JwtTokenDto token = jwtTokenProvider.createToken("example@google.com");
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token.accessToken());
+
+        GrantedAuthority grantedAuthority = authentication.getAuthorities().stream().findFirst()
+            .orElse(null);
+
+        assertThat(grantedAuthority).isNotNull();
+        assertThat(grantedAuthority.toString()).isEqualTo(Role.ROLE_OWNER.name());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Owner email으로 authentication를 조회하면 UsernameNotFoundException 발생")
+    void notExistOwnerEmailGetAuthenticationTest() {
+        JwtTokenDto token = jwtTokenProvider.createToken("example@naver.com");
+
+        assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(token.accessToken()))
+            .isInstanceOf(UsernameNotFoundException.class);
+    }
+}

--- a/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
@@ -9,7 +9,6 @@ import com.odiga.owner.dao.OwnerRepository;
 import com.odiga.owner.entity.Owner;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
@@ -4,21 +4,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.odiga.common.type.Role;
+import com.odiga.config.TestConfig;
 import com.odiga.owner.application.OwnerUserDetailsService;
 import com.odiga.owner.dao.OwnerRepository;
 import com.odiga.owner.entity.Owner;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
+@Import(TestConfig.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class JwtTokenProviderTest {
 
@@ -42,6 +46,11 @@ class JwtTokenProviderTest {
             .email("example@google.com")
             .password("password")
             .build();
+    }
+
+    @AfterEach
+    void clear() {
+        ownerRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/odiga/global/jwt/JwtTokenProviderTest.java
@@ -7,7 +7,9 @@ import com.odiga.common.type.Role;
 import com.odiga.owner.application.OwnerUserDetailsService;
 import com.odiga.owner.dao.OwnerRepository;
 import com.odiga.owner.entity.Owner;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ class JwtTokenProviderTest {
 
     Owner owner;
 
+
     @BeforeEach
     void init() {
         String secretKey = "secretKeySecretKeySecretKeySecretKeySecretKeysecretKeySecretKeySecretKeySecretKeySecretKey";
@@ -51,8 +54,18 @@ class JwtTokenProviderTest {
     }
 
     @Test
+    @DisplayName("유효 기간이 지나지 않은 access token의 claims 조회한 경우 claims를 정상적으로 조회한다")
+    void expireTimeTest() {
+
+        JwtTokenDto token = jwtTokenProvider.createToken("example@google.com");
+        Claims claims = jwtTokenProvider.getClaims(token.accessToken());
+
+        assertThat(claims).isNotNull();
+    }
+
+    @Test
     @DisplayName("유효 기간이 지난 access token의 claims 조회한 경우 예외를 발생")
-    void expireTimeTest() throws InterruptedException {
+    void expireTimeTestFail() throws InterruptedException {
         JwtTokenDto token = jwtTokenProvider.createToken("example@google.com");
         Thread.sleep(2000);
 

--- a/src/test/java/com/odiga/owner/application/OwnerAuthServiceTest.java
+++ b/src/test/java/com/odiga/owner/application/OwnerAuthServiceTest.java
@@ -1,0 +1,80 @@
+package com.odiga.owner.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.odiga.global.jwt.JwtTokenDto;
+import com.odiga.global.jwt.JwtTokenProvider;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.dto.OwnerInfoResponseDto;
+import com.odiga.owner.dto.OwnerLoginRequestDto;
+import com.odiga.owner.dto.OwnerSignupRequestDto;
+import com.odiga.owner.entity.Owner;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerAuthServiceTest {
+
+    @InjectMocks
+    OwnerAuthService ownerAuthService;
+
+    @Mock
+    OwnerRepository ownerRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    Owner owner;
+
+
+    @BeforeEach
+    void init() {
+        owner = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("name")
+            .build();
+    }
+
+    @Test
+    void ownerSignupTest() {
+        when(ownerRepository.existsByEmail("example@google.com")).thenReturn(false);
+        when(ownerRepository.save(any(Owner.class))).thenReturn(owner);
+        when(passwordEncoder.encode("password")).thenReturn("password");
+
+        OwnerSignupRequestDto ownerSignupRequestDto = new OwnerSignupRequestDto("example@google.com", "password", "name");
+        OwnerInfoResponseDto ownerInfoResponseDto = ownerAuthService.signupOwner(ownerSignupRequestDto);
+
+        verify(ownerRepository, times(1)).save(any(Owner.class));
+
+        assertThat(ownerInfoResponseDto.email()).isEqualTo(owner.getUsername());
+        assertThat(ownerInfoResponseDto.name()).isEqualTo(owner.getName());
+    }
+
+    @Test
+    void ownerLoginTest() {
+        OwnerLoginRequestDto ownerLoginRequestDto = new OwnerLoginRequestDto("example@google.com", "password");
+
+        when(ownerRepository.findByEmail("example@google.com")).thenReturn(Optional.ofNullable(owner));
+        when(passwordEncoder.matches(owner.getPassword(), ownerLoginRequestDto.password())).thenReturn(true);
+        when(jwtTokenProvider.createToken("example@google.com")).thenReturn(JwtTokenDto.of("accessToken", "refreshToken"));
+
+        JwtTokenDto tokenDto = ownerAuthService.loginOwner(ownerLoginRequestDto);
+
+        assertThat(tokenDto.accessToken()).isNotNull();
+        assertThat(tokenDto.refreshToken()).isNotNull();
+    }
+}

--- a/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceTest.java
+++ b/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceTest.java
@@ -3,16 +3,20 @@ package com.odiga.owner.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.odiga.common.type.Role;
+import com.odiga.config.TestConfig;
 import com.odiga.owner.dao.OwnerRepository;
 import com.odiga.owner.entity.Owner;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.GrantedAuthority;
 
+@Import(TestConfig.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class OwnerUserDetailsServiceTest {
 
@@ -31,6 +35,11 @@ class OwnerUserDetailsServiceTest {
             .build();
 
         ownerRepository.save(owner);
+    }
+
+    @AfterEach
+    void clear() {
+        ownerRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceTest.java
+++ b/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceTest.java
@@ -1,0 +1,47 @@
+package com.odiga.owner.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.odiga.common.type.Role;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.core.GrantedAuthority;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class OwnerUserDetailsServiceTest {
+
+    @Autowired
+    OwnerUserDetailsService ownerUserDetailsService;
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    @BeforeEach
+    void init() {
+        Owner owner = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("name")
+            .build();
+
+        ownerRepository.save(owner);
+    }
+
+    @Test
+    @DisplayName("")
+    void findOwnerByUsernameTest() {
+        Owner owner = ownerUserDetailsService.loadUserByUsername("example@google.com");
+
+        GrantedAuthority grantedAuthority = owner.getAuthorities().stream().findFirst()
+            .orElse(null);
+
+        assertThat(grantedAuthority).isNotNull();
+        assertThat(grantedAuthority.toString()).isEqualTo(Role.ROLE_OWNER.name());
+    }
+}

--- a/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/odiga/owner/application/OwnerUserDetailsServiceUnitTest.java
@@ -1,0 +1,54 @@
+package com.odiga.owner.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.odiga.common.type.Role;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerUserDetailsServiceUnitTest {
+
+    @InjectMocks
+    OwnerUserDetailsService ownerUserDetailsService;
+
+    @Mock
+    OwnerRepository ownerRepository;
+
+    Owner owner;
+
+    @BeforeEach
+    void init() {
+        owner = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("name")
+            .build();
+    }
+
+    @Test
+    @DisplayName("Owner의 email로 owner를 조회")
+    void findOwnerByUsernameTest() {
+
+        when(ownerRepository.findByEmail(owner.getEmail())).thenReturn(Optional.of(owner));
+
+        Owner findOwner = ownerUserDetailsService.loadUserByUsername("example@google.com");
+
+        GrantedAuthority grantedAuthority = findOwner.getAuthorities().stream().findFirst()
+            .orElse(null);
+
+        assertThat(findOwner.getUsername()).isEqualTo(owner.getUsername());
+        assertThat(grantedAuthority).isNotNull();
+        assertThat(grantedAuthority.toString()).isEqualTo(Role.ROLE_OWNER.name());
+    }
+}

--- a/src/test/java/com/odiga/owner/dao/OwnerRepositoryTest.java
+++ b/src/test/java/com/odiga/owner/dao/OwnerRepositoryTest.java
@@ -73,6 +73,36 @@ class OwnerRepositoryTest {
     }
 
     @Test
+    @DisplayName("존재하는 이메일로 Owner 찾기 - existBy")
+    void existByEmailOwnerTest() {
+        String email = "example@google.com";
+
+        Owner owner = Owner.builder()
+            .email(email)
+            .password("password")
+            .name("owner1")
+            .build();
+
+        ownerRepository.save(owner);
+
+        boolean exists = ownerRepository.existsByEmail(email);
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 Owner 찾기 - existBy")
+    void existByEmailOwnerFailTest() {
+        String email = "example@google.com";
+
+        boolean exists = ownerRepository.existsByEmail(email);
+
+        assertThat(exists).isFalse();
+    }
+
+
+
+    @Test
     @DisplayName("존재하는 이메일로 Owner 찾기")
     void findByEmailOwnerTest() {
         String email = "example@google.com";

--- a/src/test/java/com/odiga/owner/dao/OwnerRepositoryTest.java
+++ b/src/test/java/com/odiga/owner/dao/OwnerRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.odiga.owner.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.odiga.global.config.JpaConfig;
+import com.odiga.owner.entity.Owner;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@Import(JpaConfig.class)
+@DataJpaTest
+class OwnerRepositoryTest {
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    @Test
+    @DisplayName("Owner 생성 테스트(성공)")
+    void createOwnerTest() {
+        Owner owner = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("owner")
+            .build();
+
+        ownerRepository.save(owner);
+
+        Owner findOwner = ownerRepository.findById(owner.getId()).orElseThrow();
+
+        assertThat(findOwner.getId()).isEqualTo(owner.getId());
+        assertThat(owner.getCreatedAt()).isNotNull();
+        assertThat(owner.getUpdateAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Owner 생성 테스트(실패 - email 누락)")
+    void creatOwnerTestFailByNullEmail() {
+        Owner owner = Owner.builder()
+            .password("password")
+            .name("owner")
+            .build();
+
+        assertThatThrownBy(() -> ownerRepository.save(owner)).isInstanceOf(
+            DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("Owner 생성 테스트(실패 - email 중복)")
+    void creatOwnerTestFailByConfEmailConflict() {
+
+        Owner owner1 = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("owner")
+            .build();
+
+        Owner owner2 = Owner.builder()
+            .email("example@google.com")
+            .password("password")
+            .name("owner")
+            .build();
+
+        ownerRepository.save(owner1);
+
+        assertThatThrownBy(() -> ownerRepository.save(owner2)).isInstanceOf(
+            DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("존재하는 이메일로 Owner 찾기")
+    void findByEmailOwnerTest() {
+        String email = "example@google.com";
+
+        Owner owner = Owner.builder()
+            .email(email)
+            .password("password")
+            .name("owner1")
+            .build();
+
+        ownerRepository.save(owner);
+
+        Optional<Owner> findOwner = ownerRepository.findByEmail(email);
+
+        assertThat(findOwner.isPresent()).isTrue();
+        assertThat(findOwner.get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("존재하는 않는 이메일로 Owner 찾기")
+    void findByEmailOwnerTestFail() {
+        String email = "example@google.com";
+
+        Owner owner = Owner.builder()
+            .email(email)
+            .password("password")
+            .name("owner1")
+            .build();
+
+        ownerRepository.save(owner);
+
+        String findEmail = "example@naver.com";
+
+        Optional<Owner> findOwner = ownerRepository.findByEmail(findEmail);
+
+        assertThat(findOwner.isEmpty()).isTrue();
+    }
+
+}


### PR DESCRIPTION
### Summary

- Owner(가게 사장의) 회원 가입 및 로그인 기능 구현

### Technical issue

- 데이터의 존재 여부를 확인 할 때 `findByXXX` VS `existsByXXX`
- `@Service` 레이어의 테스트를 진행할때 `Mockito` VS `@SpringBootTest`
- 전체적인 `ErrorCode` 인터페이스 정의로 프로젝트의 에러 코드 정의 
- record로 DTO 사용하기
- Swagger 적용 및 interface로 Controller class에 Swagger 코드 제외하기

### To Do

- jacoco로 테스트 커버리지 측정
- owner 관점에서의 store 도메인 관련 기능 구현