### PR TITLE
feat : 가게 주인 가게 메뉴 관련 기능 구현

### DIFF
--- a/src/main/java/com/odiga/menu/api/OwnerCategoryApi.java
+++ b/src/main/java/com/odiga/menu/api/OwnerCategoryApi.java
@@ -1,0 +1,75 @@
+package com.odiga.menu.api;
+
+import com.odiga.menu.dto.CategoryCreateDto;
+import com.odiga.owner.entity.Owner;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Owner Category API", description = "Owner 메뉴 Category 관련 API")
+public interface OwnerCategoryApi {
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 생성 성공", value = """
+                {
+                  "categoryId": 1,
+                  "categoryName": "카테고리"
+                }
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 생성 실패", value = """
+                {
+                  "message": "존재하지 않는 가게 입니다."
+                }
+                """),}))})
+    ResponseEntity<?> addCategory(@AuthenticationPrincipal Owner owner,
+                                  @PathVariable Long storeId,
+                                  @RequestBody CategoryCreateDto categoryCreateDto);
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 조회 성공", value = """
+                [
+                    {
+                      "categoryId": 1,
+                      "categoryName": "카테고리"
+                    },
+                    {
+                      "categoryId": 2,
+                      "categoryName": "카테고리2"
+                    }
+                ]
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 조회 실패", value = """
+                {
+                  "message": "존재하지 않는 가게 입니다."
+                }
+                """),}))})
+    ResponseEntity<?> findAllCategoryByStoreId(@PathVariable Long storeId);
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 삭제 실패", value = """
+                {
+                  "message": "존재하지 않는 가게 입니다."
+                }
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "카테고리 삭제 실패", value = """
+                {
+                  "message": "존재하지 않는 카테고리 입니다."
+                }
+                """),}))})
+    ResponseEntity<?> deleteCategoryByCategoryId(@AuthenticationPrincipal Owner owner,
+                                                 @PathVariable Long storeId,
+                                                 @PathVariable Long categoryId);
+}

--- a/src/main/java/com/odiga/menu/api/OwnerMenuApi.java
+++ b/src/main/java/com/odiga/menu/api/OwnerMenuApi.java
@@ -1,0 +1,73 @@
+package com.odiga.menu.api;
+
+import com.odiga.menu.dto.MenuCreateDto;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Owner Menu API", description = "Owner 메뉴 관련 API")
+public interface OwnerMenuApi {
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "메뉴 생성 성공", value = """
+                {
+                  "menuId": 1,
+                  "menuId": "메뉴",
+                  "price" : 10000,
+                  "imageUrl" : "https://example.com/image.jpg"
+                }
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "메뉴 생성 실패", value = """
+                {
+                  "message": "존재하지 않는 카테고리 입니다."
+                }
+                """),}))})
+    ResponseEntity<?> saveMenu(@PathVariable Long categoryId,
+                               @RequestPart MultipartFile menuImage,
+                               @RequestPart MenuCreateDto menuCreateDto);
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "메뉴 조회 성공", value = """
+                [
+                    {
+                      "menuId": 1,
+                      "menuId": "메뉴",
+                      "price" : 10000,
+                      "imageUrl" : "https://example.com/image.jpg"
+                    },
+                    {
+                      "menuId": 2,
+                      "menuId": "메뉴2",
+                      "price" : 20000,
+                      "imageUrl" : "https://example.com/image2.jpg"
+                    }
+                ]
+                """),})),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "메뉴 조회 실패", value = """
+                {
+                  "message": "존재하지 않는 카테고리 입니다."
+                }
+                """),}))})
+    ResponseEntity<?> findMenuByCategoryId(@PathVariable Long categoryId);
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "메뉴 삭제 실패", value = """
+                {
+                  "message": "존재하지 않는 메뉴 입니다."
+                }
+                """),})),})
+    ResponseEntity<?> deleteMenuById(@PathVariable Long categoryId,
+                                     @PathVariable Long menuId);
+}

--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -41,7 +41,7 @@ public class OwnerCategoryService {
 
     @Transactional(readOnly = true)
     public List<CategoryInfoDto> findAllCategoryByStoreId(Long storeId) {
-        if (storeRepository.existsById(storeId)) {
+        if (!storeRepository.existsById(storeId)) {
             throw new CustomException(StoreErrorCode.NOT_FOUND_STORE);
         }
 

--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -1,0 +1,43 @@
+package com.odiga.menu.application;
+
+import com.odiga.global.exception.CustomException;
+import com.odiga.menu.dao.CategoryRepository;
+import com.odiga.menu.dto.CategoryCreateDto;
+import com.odiga.menu.dto.CategoryInfoDto;
+import com.odiga.menu.entity.Category;
+import com.odiga.owner.entity.Owner;
+import com.odiga.store.dao.StoreRepository;
+import com.odiga.store.entity.Store;
+import com.odiga.store.exception.StoreErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerCategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final StoreRepository storeRepository;
+
+
+    @Transactional
+    public CategoryInfoDto saveCategoryByStoreId(Owner owner, Long storeId, CategoryCreateDto categoryCreateDto) {
+
+        Store store = storeRepository.findById(storeId)
+            .orElseThrow(() -> new CustomException(StoreErrorCode.NOT_FOUND_STORE));
+
+        store.validateOwner(owner.getId());
+
+        Category category = Category.builder()
+            .name(categoryCreateDto.categoryName())
+            .store(store)
+            .build();
+
+        categoryRepository.save(category);
+
+        store.addCategory(category);
+
+        return CategoryInfoDto.from(category);
+    }
+}

--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -5,10 +5,12 @@ import com.odiga.menu.dao.CategoryRepository;
 import com.odiga.menu.dto.CategoryCreateDto;
 import com.odiga.menu.dto.CategoryInfoDto;
 import com.odiga.menu.entity.Category;
+import com.odiga.menu.exception.CategoryErrorCode;
 import com.odiga.owner.entity.Owner;
 import com.odiga.store.dao.StoreRepository;
 import com.odiga.store.entity.Store;
 import com.odiga.store.exception.StoreErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +25,6 @@ public class OwnerCategoryService {
 
     @Transactional
     public CategoryInfoDto saveCategoryByStoreId(Owner owner, Long storeId, CategoryCreateDto categoryCreateDto) {
-
         Store store = storeRepository.findById(storeId)
             .orElseThrow(() -> new CustomException(StoreErrorCode.NOT_FOUND_STORE));
 
@@ -39,5 +40,28 @@ public class OwnerCategoryService {
         store.addCategory(category);
 
         return CategoryInfoDto.from(category);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryInfoDto> findAllCategoryByStoreId(Long storeId) {
+        storeRepository.findById(storeId)
+            .orElseThrow(() -> new CustomException(StoreErrorCode.NOT_FOUND_STORE));
+
+        List<Category> categories = categoryRepository.findByStoreId(storeId);
+
+        return categories.stream().map(CategoryInfoDto::from).toList();
+    }
+
+    @Transactional
+    public void deleteCategoryByCategoryId(Owner owner, Long storeId, Long categoryId) {
+        Store store = storeRepository.findById(storeId)
+            .orElseThrow(() -> new CustomException(StoreErrorCode.NOT_FOUND_STORE));
+
+        store.validateOwner(owner.getId());
+
+        Category category = categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY));
+
+        categoryRepository.delete(category);
     }
 }

--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -30,10 +30,7 @@ public class OwnerCategoryService {
 
         store.validateOwner(owner.getId());
 
-        Category category = Category.builder()
-            .name(categoryCreateDto.categoryName())
-            .store(store)
-            .build();
+        Category category = categoryCreateDto.toEntity(store);
 
         categoryRepository.save(category);
 
@@ -44,8 +41,9 @@ public class OwnerCategoryService {
 
     @Transactional(readOnly = true)
     public List<CategoryInfoDto> findAllCategoryByStoreId(Long storeId) {
-        storeRepository.findById(storeId)
-            .orElseThrow(() -> new CustomException(StoreErrorCode.NOT_FOUND_STORE));
+        if (storeRepository.existsById(storeId)) {
+            throw new CustomException(StoreErrorCode.NOT_FOUND_STORE);
+        }
 
         List<Category> categories = categoryRepository.findByStoreId(storeId);
 

--- a/src/main/java/com/odiga/menu/application/OwnerMenuService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerMenuService.java
@@ -33,7 +33,7 @@ public class OwnerMenuService {
 
         String imageUrl = s3ImageService.uploadS3(DIR_NAME, menuImage);
 
-        Menu menu = menuCreateDto.toEntity(category, imageUrl);
+        Menu menu = menuCreateDto.toEntity(imageUrl);
         category.addMenu(menu);
 
         menuRepository.save(menu);

--- a/src/main/java/com/odiga/menu/application/OwnerMenuService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerMenuService.java
@@ -27,7 +27,7 @@ public class OwnerMenuService {
     private final S3ImageService s3ImageService;
 
     @Transactional
-    public MenuInfoDto saveMenu(Long categoryId, MultipartFile menuImage, MenuCreateDto menuCreateDto) {
+    public MenuInfoDto addMenu(Long categoryId, MultipartFile menuImage, MenuCreateDto menuCreateDto) {
         Category category = categoryRepository.findById(categoryId)
             .orElseThrow(() -> new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/com/odiga/menu/application/OwnerMenuService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerMenuService.java
@@ -1,0 +1,62 @@
+package com.odiga.menu.application;
+
+import com.odiga.global.exception.CustomException;
+import com.odiga.global.s3.application.S3ImageService;
+import com.odiga.menu.dao.CategoryRepository;
+import com.odiga.menu.dao.MenuRepository;
+import com.odiga.menu.dto.MenuCreateDto;
+import com.odiga.menu.dto.MenuInfoDto;
+import com.odiga.menu.entity.Category;
+import com.odiga.menu.entity.Menu;
+import com.odiga.menu.exception.CategoryErrorCode;
+import com.odiga.menu.exception.MenuErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerMenuService {
+
+    private static final String DIR_NAME = "menu";
+
+    private final MenuRepository menuRepository;
+    private final CategoryRepository categoryRepository;
+    private final S3ImageService s3ImageService;
+
+    @Transactional
+    public MenuInfoDto saveMenu(Long categoryId, MultipartFile menuImage, MenuCreateDto menuCreateDto) {
+        Category category = categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY));
+
+        String imageUrl = s3ImageService.uploadS3(DIR_NAME, menuImage);
+
+        Menu menu = menuCreateDto.toEntity(category, imageUrl);
+        category.addMenu(menu);
+
+        menuRepository.save(menu);
+
+        return MenuInfoDto.from(menu);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MenuInfoDto> findMenuByCategoryId(Long categoryId) {
+        if (!categoryRepository.existsById(categoryId)) {
+            throw new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY);
+        }
+
+        List<Menu> menus = menuRepository.findByCategoryId(categoryId);
+
+        return menus.stream().map(MenuInfoDto::from).toList();
+    }
+
+    @Transactional
+    public void deleteById(Long menuId) {
+        Menu menu = menuRepository.findById(menuId)
+            .orElseThrow(() -> new CustomException(MenuErrorCode.NOT_FOUND_MENU));
+
+        menuRepository.delete(menu);
+    }
+}

--- a/src/main/java/com/odiga/menu/controller/OwnerCategoryController.java
+++ b/src/main/java/com/odiga/menu/controller/OwnerCategoryController.java
@@ -1,0 +1,46 @@
+package com.odiga.menu.controller;
+
+import com.odiga.menu.api.OwnerCategoryApi;
+import com.odiga.menu.application.OwnerCategoryService;
+import com.odiga.menu.dto.CategoryCreateDto;
+import com.odiga.owner.entity.Owner;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/owners/stores/{storeId}/categories")
+@RequiredArgsConstructor
+public class OwnerCategoryController implements OwnerCategoryApi {
+
+    private final OwnerCategoryService ownerCategoryService;
+
+    @PostMapping
+    public ResponseEntity<?> addCategory(@AuthenticationPrincipal Owner owner,
+                                         @PathVariable Long storeId,
+                                         @RequestBody CategoryCreateDto categoryCreateDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ownerCategoryService.saveCategoryByStoreId(owner, storeId, categoryCreateDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> findAllCategoryByStoreId(@PathVariable Long storeId) {
+        return ResponseEntity.ok(ownerCategoryService.findAllCategoryByStoreId(storeId));
+    }
+
+    @DeleteMapping("{categoryId}")
+    public ResponseEntity<?> deleteCategoryByCategoryId(@AuthenticationPrincipal Owner owner,
+                                                        @PathVariable Long storeId,
+                                                        @PathVariable Long categoryId) {
+        ownerCategoryService.deleteCategoryByCategoryId(owner, storeId, categoryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/odiga/menu/controller/OwnerMenusController.java
+++ b/src/main/java/com/odiga/menu/controller/OwnerMenusController.java
@@ -1,0 +1,45 @@
+package com.odiga.menu.controller;
+
+import com.odiga.menu.api.OwnerMenuApi;
+import com.odiga.menu.application.OwnerMenuService;
+import com.odiga.menu.dto.MenuCreateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("api/v1/owners/categories/{categoryId}/menus")
+@RequiredArgsConstructor
+public class OwnerMenusController implements OwnerMenuApi {
+
+    private final OwnerMenuService ownerMenuService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> saveMenu(@PathVariable Long categoryId,
+                                      @RequestPart MultipartFile menuImage,
+                                      @RequestPart MenuCreateDto menuCreateDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ownerMenuService.saveMenu(categoryId, menuImage, menuCreateDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> findMenuByCategoryId(@PathVariable Long categoryId) {
+        return ResponseEntity.ok(ownerMenuService.findMenuByCategoryId(categoryId));
+    }
+
+    @DeleteMapping("{menuId}")
+    public ResponseEntity<?> deleteMenuById(@PathVariable Long categoryId, @PathVariable Long menuId) {
+        ownerMenuService.deleteById(menuId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/odiga/menu/controller/OwnerMenusController.java
+++ b/src/main/java/com/odiga/menu/controller/OwnerMenusController.java
@@ -28,7 +28,7 @@ public class OwnerMenusController implements OwnerMenuApi {
                                       @RequestPart MultipartFile menuImage,
                                       @RequestPart MenuCreateDto menuCreateDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerMenuService.saveMenu(categoryId, menuImage, menuCreateDto));
+            .body(ownerMenuService.addMenu(categoryId, menuImage, menuCreateDto));
     }
 
     @GetMapping

--- a/src/main/java/com/odiga/menu/dao/CategoryRepository.java
+++ b/src/main/java/com/odiga/menu/dao/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.odiga.menu.dao;
+
+import com.odiga.menu.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/com/odiga/menu/dao/CategoryRepository.java
+++ b/src/main/java/com/odiga/menu/dao/CategoryRepository.java
@@ -1,8 +1,10 @@
 package com.odiga.menu.dao;
 
 import com.odiga.menu.entity.Category;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    List<Category> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/odiga/menu/dao/MenuRepository.java
+++ b/src/main/java/com/odiga/menu/dao/MenuRepository.java
@@ -1,0 +1,10 @@
+package com.odiga.menu.dao;
+
+import com.odiga.menu.entity.Menu;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    List<Menu> findByCategoryId(Long categoryId);
+}

--- a/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
+++ b/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
@@ -1,5 +1,10 @@
 package com.odiga.menu.dto;
 
-public record CategoryCreateDto(String categoryName) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "Owner 카테고리 등록 요청")
+public record CategoryCreateDto(
+    @Schema(description = "메뉴 카테고리 이름", example = "메인 메뉴")
+    String categoryName) {
 
 }

--- a/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
+++ b/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
@@ -1,10 +1,19 @@
 package com.odiga.menu.dto;
 
+import com.odiga.menu.entity.Category;
+import com.odiga.store.entity.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "Owner 카테고리 등록 요청")
 public record CategoryCreateDto(
     @Schema(description = "메뉴 카테고리 이름", example = "메인 메뉴")
     String categoryName) {
+
+    public Category toEntity(Store store) {
+        return Category.builder()
+            .name(categoryName)
+            .store(store)
+            .build();
+    }
 
 }

--- a/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
+++ b/src/main/java/com/odiga/menu/dto/CategoryCreateDto.java
@@ -1,0 +1,5 @@
+package com.odiga.menu.dto;
+
+public record CategoryCreateDto(String categoryName) {
+
+}

--- a/src/main/java/com/odiga/menu/dto/CategoryInfoDto.java
+++ b/src/main/java/com/odiga/menu/dto/CategoryInfoDto.java
@@ -1,0 +1,12 @@
+package com.odiga.menu.dto;
+
+import com.odiga.menu.entity.Category;
+
+public record CategoryInfoDto(Long categoryId, String categoryName, Long storeId) {
+
+
+    public static CategoryInfoDto from(Category category) {
+        return new CategoryInfoDto(category.getId(), category.getName(), category.getStore().getId());
+    }
+
+}

--- a/src/main/java/com/odiga/menu/dto/CategoryInfoDto.java
+++ b/src/main/java/com/odiga/menu/dto/CategoryInfoDto.java
@@ -2,11 +2,11 @@ package com.odiga.menu.dto;
 
 import com.odiga.menu.entity.Category;
 
-public record CategoryInfoDto(Long categoryId, String categoryName, Long storeId) {
+public record CategoryInfoDto(Long categoryId, String categoryName) {
 
 
     public static CategoryInfoDto from(Category category) {
-        return new CategoryInfoDto(category.getId(), category.getName(), category.getStore().getId());
+        return new CategoryInfoDto(category.getId(), category.getName());
     }
 
 }

--- a/src/main/java/com/odiga/menu/dto/MenuCreateDto.java
+++ b/src/main/java/com/odiga/menu/dto/MenuCreateDto.java
@@ -1,6 +1,5 @@
 package com.odiga.menu.dto;
 
-import com.odiga.menu.entity.Category;
 import com.odiga.menu.entity.Menu;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,12 +11,11 @@ public record MenuCreateDto(
     @Schema(description = "등록할 메뉴 가격", example = "21900")
     int price) {
 
-    public Menu toEntity(Category category, String imageUrl) {
+    public Menu toEntity(String imageUrl) {
         return Menu.builder()
             .name(menuName)
             .price(price)
             .titleImageUrl(imageUrl)
-            .category(category)
             .build();
     }
 }

--- a/src/main/java/com/odiga/menu/dto/MenuCreateDto.java
+++ b/src/main/java/com/odiga/menu/dto/MenuCreateDto.java
@@ -1,0 +1,23 @@
+package com.odiga.menu.dto;
+
+import com.odiga.menu.entity.Category;
+import com.odiga.menu.entity.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "Owner 메뉴 등록 요청")
+public record MenuCreateDto(
+    @Schema(description = "등록할 메뉴 이름", example = "치킨")
+    String menuName,
+
+    @Schema(description = "등록할 메뉴 가격", example = "21900")
+    int price) {
+
+    public Menu toEntity(Category category, String imageUrl) {
+        return Menu.builder()
+            .name(menuName)
+            .price(price)
+            .titleImageUrl(imageUrl)
+            .category(category)
+            .build();
+    }
+}

--- a/src/main/java/com/odiga/menu/dto/MenuInfoDto.java
+++ b/src/main/java/com/odiga/menu/dto/MenuInfoDto.java
@@ -1,0 +1,10 @@
+package com.odiga.menu.dto;
+
+import com.odiga.menu.entity.Menu;
+
+public record MenuInfoDto(Long menuId, String menuName, int price, String imageUrl) {
+
+    public static MenuInfoDto from(Menu menu) {
+        return new MenuInfoDto(menu.getId(), menu.getName(), menu.getPrice(), menu.getTitleImageUrl());
+    }
+}

--- a/src/main/java/com/odiga/menu/entity/Category.java
+++ b/src/main/java/com/odiga/menu/entity/Category.java
@@ -33,15 +33,12 @@ public class Category extends BaseEntity {
     @JoinColumn(name = "STORE_ID")
     private Store store;
 
+    @Builder.Default
     @OneToMany(mappedBy = "category")
     private List<Menu> menus = new ArrayList<>();
 
-//    public void setStore(Store store) {
-//        this.store = store;
-//        store.addCategory(this);
-//    }
-//
-//    public void addMenu(Menu menu) {
-//        menus.add(menu);
-//    }
+    public void addMenu(Menu menu) {
+        menus.add(menu);
+    }
+
 }

--- a/src/main/java/com/odiga/menu/entity/Category.java
+++ b/src/main/java/com/odiga/menu/entity/Category.java
@@ -39,6 +39,6 @@ public class Category extends BaseEntity {
 
     public void addMenu(Menu menu) {
         menus.add(menu);
+        menu.setCategory(this);
     }
-
 }

--- a/src/main/java/com/odiga/menu/entity/Category.java
+++ b/src/main/java/com/odiga/menu/entity/Category.java
@@ -11,8 +11,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Category extends BaseEntity {
 
     @Id

--- a/src/main/java/com/odiga/menu/entity/Menu.java
+++ b/src/main/java/com/odiga/menu/entity/Menu.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -29,11 +30,7 @@ public class Menu extends BaseEntity {
 
     private String titleImageUrl;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
-
-    public void setCategory(Category category) {
-        this.category = category;
-        category.addMenu(this);
-    }
 }

--- a/src/main/java/com/odiga/menu/entity/Menu.java
+++ b/src/main/java/com/odiga/menu/entity/Menu.java
@@ -7,8 +7,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Menu extends BaseEntity {
 
     @Id
@@ -24,8 +32,8 @@ public class Menu extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
 
-//    public void setCategory(Category category) {
-//        this.category = category;
-//        category.addMenu(this);
-//    }
+    public void setCategory(Category category) {
+        this.category = category;
+        category.addMenu(this);
+    }
 }

--- a/src/main/java/com/odiga/menu/exception/CategoryErrorCode.java
+++ b/src/main/java/com/odiga/menu/exception/CategoryErrorCode.java
@@ -1,0 +1,25 @@
+package com.odiga.menu.exception;
+
+import com.odiga.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+
+
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/odiga/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/odiga/menu/exception/MenuErrorCode.java
@@ -1,0 +1,25 @@
+package com.odiga.menu.exception;
+
+import com.odiga.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum MenuErrorCode implements ErrorCode {
+
+
+    NOT_FOUND_MENU(HttpStatus.NOT_FOUND, "존재하지 않는 메뉴 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/odiga/store/entity/Store.java
+++ b/src/main/java/com/odiga/store/entity/Store.java
@@ -109,7 +109,7 @@ public class Store extends BaseEntity {
         }
     }
 
-//    public void addCategory(Category category) {
-//        categories.add(category);
-//    }
+    public void addCategory(Category category) {
+        categories.add(category);
+    }
 }

--- a/src/main/java/com/odiga/store/entity/Store.java
+++ b/src/main/java/com/odiga/store/entity/Store.java
@@ -60,6 +60,7 @@ public class Store extends BaseEntity {
     @Builder.Default
     private StoreStatus storeStatus = StoreStatus.ClOSE;
 
+    @Builder.Default
     @OneToMany(mappedBy = "store")
     private List<Category> categories = new ArrayList<>();
 

--- a/src/test/java/com/odiga/menu/application/OwnerCategoryServiceTest.java
+++ b/src/test/java/com/odiga/menu/application/OwnerCategoryServiceTest.java
@@ -1,0 +1,135 @@
+package com.odiga.menu.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.odiga.global.exception.CustomException;
+import com.odiga.menu.dao.CategoryRepository;
+import com.odiga.menu.dto.CategoryCreateDto;
+import com.odiga.menu.dto.CategoryInfoDto;
+import com.odiga.menu.entity.Category;
+import com.odiga.menu.exception.CategoryErrorCode;
+import com.odiga.owner.entity.Owner;
+import com.odiga.store.dao.StoreRepository;
+import com.odiga.store.entity.Store;
+import com.odiga.store.exception.StoreErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerCategoryServiceTest {
+
+
+    @InjectMocks
+    OwnerCategoryService ownerCategoryService;
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @Mock
+    StoreRepository storeRepository;
+
+    Store store;
+
+    Owner owner;
+
+    Long storeId = 1L;
+
+    @BeforeEach
+    void init() {
+        owner = Owner.builder()
+            .id(1L)
+            .build();
+
+        store = Store.builder()
+            .name("store")
+            .owner(owner)
+            .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    void saveCategoryTest() {
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+
+        CategoryCreateDto categoryCreateDto = new CategoryCreateDto("category name");
+
+        CategoryInfoDto categoryInfoDto = ownerCategoryService.saveCategoryByStoreId(owner, storeId, categoryCreateDto);
+
+        assertThat(categoryInfoDto.categoryName()).isEqualTo(categoryCreateDto.categoryName());
+
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 없는 가게")
+    void saveCategoryFailTest() {
+        CategoryCreateDto categoryCreateDto = new CategoryCreateDto("category name");
+
+        assertThatThrownBy(() -> ownerCategoryService.saveCategoryByStoreId(owner, storeId, categoryCreateDto))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", StoreErrorCode.NOT_FOUND_STORE);
+    }
+
+    @Test
+    @DisplayName("가게의 모든 카테고리 조회")
+    void findAllCategoryByStoreIdTest() {
+        when(storeRepository.existsById(storeId)).thenReturn(true);
+
+        List<Category> categories = new ArrayList<>(List.of(
+            Category.builder().name("category1").build(), Category.builder().name("category2").build()));
+
+        when(categoryRepository.findByStoreId(storeId)).thenReturn(categories);
+
+        List<CategoryInfoDto> result = ownerCategoryService.findAllCategoryByStoreId(storeId);
+
+        assertThat(result.size()).isEqualTo(categories.size());
+    }
+
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    void deleteByIdTest() {
+        Long categoryId = 1L;
+
+        Category category = Category.builder()
+            .id(categoryId)
+            .build();
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+
+        ownerCategoryService.deleteCategoryByCategoryId(owner, storeId, categoryId);
+
+        verify(categoryRepository, times(1)).delete(category);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 없는 가게")
+    void deleteByIdFailNotFoundStoreTest() {
+        assertThatThrownBy(() -> ownerCategoryService.deleteCategoryByCategoryId(owner, storeId, 1L))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", StoreErrorCode.NOT_FOUND_STORE);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 없는 카테고리")
+    void deleteByIdFailNotFoundCategoryTest() {
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        assertThatThrownBy(() -> ownerCategoryService.deleteCategoryByCategoryId(owner, storeId, 1L))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", CategoryErrorCode.NOT_FOUND_CATEGORY);
+    }
+}

--- a/src/test/java/com/odiga/menu/application/OwnerMenuServiceTest.java
+++ b/src/test/java/com/odiga/menu/application/OwnerMenuServiceTest.java
@@ -1,0 +1,123 @@
+package com.odiga.menu.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.odiga.global.exception.CustomException;
+import com.odiga.global.s3.application.S3ImageService;
+import com.odiga.menu.dao.CategoryRepository;
+import com.odiga.menu.dao.MenuRepository;
+import com.odiga.menu.dto.MenuCreateDto;
+import com.odiga.menu.dto.MenuInfoDto;
+import com.odiga.menu.entity.Category;
+import com.odiga.menu.entity.Menu;
+import com.odiga.menu.exception.CategoryErrorCode;
+import com.odiga.menu.exception.MenuErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerMenuServiceTest {
+
+    @InjectMocks
+    OwnerMenuService ownerMenuService;
+    @Mock
+    MenuRepository menuRepository;
+    @Mock
+    CategoryRepository categoryRepository;
+    @Mock
+    S3ImageService s3ImageService;
+
+    @Test
+    @DisplayName("메뉴 저장 성공")
+    void addMenuTest() {
+        Long categoryId = 1L;
+        Category category = new Category();
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+        MenuCreateDto menuCreateDto = new MenuCreateDto("menu", 1000);
+        MenuInfoDto result = ownerMenuService.addMenu(categoryId, new MockMultipartFile("menuImage", new byte[0]), menuCreateDto);
+
+        assertThat(result.menuName()).isEqualTo(menuCreateDto.menuName());
+
+        verify(menuRepository, times(1)).save(any(Menu.class));
+    }
+
+    @Test
+    @DisplayName("메뉴 저장 실패 - 존재하지 않는 카테고리에 메뉴 추가")
+    void addMenuFailTest() {
+        Long categoryId = 1L;
+
+        MenuCreateDto menuCreateDto = new MenuCreateDto("menu", 1000);
+
+        assertThatThrownBy(() -> ownerMenuService.addMenu(categoryId, new MockMultipartFile("menuImage", new byte[0]), menuCreateDto))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", CategoryErrorCode.NOT_FOUND_CATEGORY);
+
+        verify(menuRepository, times(0)).save(any(Menu.class));
+    }
+
+    @Test
+    @DisplayName("카테고리로 메뉴 조회 성공")
+    void findMenuByCategoryIdTest() {
+        Long categoryId = 1L;
+        List<Menu> menus = new ArrayList<>(List.of(new Menu(), new Menu()));
+
+        when(categoryRepository.existsById(categoryId)).thenReturn(true);
+        when(menuRepository.findByCategoryId(categoryId)).thenReturn(menus);
+
+        List<MenuInfoDto> result = ownerMenuService.findMenuByCategoryId(categoryId);
+        assertThat(result.size()).isEqualTo(menus.size());
+    }
+
+    @Test
+    @DisplayName("카테고리로 메뉴 조회 실패 - 존재하지 않는 카테고리")
+    void findMenuByCategoryIdFailTest() {
+        Long categoryId = 1L;
+
+        when(categoryRepository.existsById(categoryId)).thenReturn(false);
+
+        assertThatThrownBy(() -> ownerMenuService.findMenuByCategoryId(categoryId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", CategoryErrorCode.NOT_FOUND_CATEGORY);
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제 성공")
+    void deleteByIdTest() {
+        Long menuId = 1L;
+        Menu menu = new Menu();
+
+        when(menuRepository.findById(menuId)).thenReturn(Optional.of(menu));
+
+        ownerMenuService.deleteById(menuId);
+
+        verify(menuRepository, times(1)).delete(menu);
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제 실패 - 존재하지 않는 메뉴")
+    void deleteByIdFailTest() {
+        Long menuId = 1L;
+        Menu menu = new Menu();
+
+        assertThatThrownBy(() -> ownerMenuService.deleteById(menuId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", MenuErrorCode.NOT_FOUND_MENU);
+
+        verify(menuRepository, times(0)).delete(menu);
+    }
+}

--- a/src/test/java/com/odiga/menu/dao/CategoryRepositoryTest.java
+++ b/src/test/java/com/odiga/menu/dao/CategoryRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.odiga.menu.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.odiga.global.config.JpaConfig;
+import com.odiga.menu.entity.Category;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
+import com.odiga.store.dao.StoreRepository;
+import com.odiga.store.entity.Store;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@DataJpaTest
+class CategoryRepositoryTest {
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    Store store;
+
+    Category category;
+
+    @BeforeEach
+    void init() {
+        Owner owner = Owner.builder()
+            .email("example@google.com")
+            .build();
+
+        ownerRepository.save(owner);
+
+        store = Store.builder()
+            .name("store")
+            .owner(owner)
+            .build();
+
+        storeRepository.save(store);
+
+        category = Category.builder()
+            .name("category")
+            .store(store)
+            .build();
+
+        categoryRepository.save(category);
+    }
+
+    @Test
+    void findByStoreIdTest() {
+        List<Category> categories = categoryRepository.findByStoreId(store.getId());
+
+        assertThat(categories.size()).isEqualTo(1);
+    }
+
+}

--- a/src/test/java/com/odiga/menu/entity/CategoryTest.java
+++ b/src/test/java/com/odiga/menu/entity/CategoryTest.java
@@ -1,0 +1,22 @@
+package com.odiga.menu.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CategoryTest {
+
+
+    @Test
+    void addMenuTest() {
+        Category category = new Category();
+        Menu menu = new Menu();
+
+        category.addMenu(menu);
+
+        List<Menu> menus = category.getMenus();
+
+        assertThat(menus.size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/odiga/store/entity/StoreTest.java
+++ b/src/test/java/com/odiga/store/entity/StoreTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.odiga.global.exception.CustomException;
+import com.odiga.menu.entity.Category;
 import com.odiga.store.exception.OwnerStoreErrorCode;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +52,24 @@ class StoreTest {
         assertThatThrownBy(store::storeClose)
             .isInstanceOf(CustomException.class)
             .hasFieldOrPropertyWithValue("errorCode", OwnerStoreErrorCode.ALREADY_CLOSE);
+    }
+
+    @Test
+    @DisplayName("가게의 카테고리 리스트에 카테고리 추기")
+    void addCategoryTest() {
+        Store store = new Store();
+
+        Category category = Category.builder()
+            .name("category1")
+            .build();
+
+        store.addCategory(category);
+
+        List<Category> categories = store.getCategories();
+        Category find = categories.stream().findFirst().get();
+
+        assertThat(categories.size()).isEqualTo(1);
+        assertThat(category.getName()).isEqualTo(find.getName());
     }
 
 }


### PR DESCRIPTION
### Summary

- 가게 카테고리 및 가게 관련 기능 구현

### Technical issue

- `toEntity` 메소드의 위치
   -  entity class  or dto class
- `@DataJpaTest` 에서 연관 관계에 대한 테스트 
  -  연관관계가 있는 Repository 테스트를 진행 할 때 다른 연관 관계가 있는 Repository를 이용하여 데이터를 만들어 놓고 테스트를 해야하는가? 
  - `CategoryRepository`하나를 테스트 하기 위해서 `StoreRepository`와 `OwnerRepository`가 필요한데 이 상황일때 어떻게 테스르를 진행해야할지 따로 sql로 미리 테스트 db에 데이터를 적재 해야하는가?

### To Do

- 가게 주인 예약 관련 기능 구현