### PR TITLE
feat : api 공통 response 구현

### DIFF
--- a/src/main/java/com/odiga/common/dto/ApiResponse.java
+++ b/src/main/java/com/odiga/common/dto/ApiResponse.java
@@ -1,0 +1,23 @@
+package com.odiga.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.odiga.global.exception.ErrorResponse;
+
+public record ApiResponse<T>(
+    boolean success,
+    @JsonInclude(Include.NON_NULL)
+    T data,
+    @JsonInclude(Include.NON_NULL)
+    ErrorResponse error
+) {
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorResponse error) {
+        return new ApiResponse<>(false, null, error);
+    }
+
+}

--- a/src/main/java/com/odiga/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/odiga/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.odiga.global.exception;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.global.exception.ErrorResponse.ValidationError;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -36,7 +37,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(makeErrorResponse(ex));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(makeErrorResponse(ex)));
     }
 
     private ResponseEntity<?> handleExceptionInternal(ErrorCode errorCode) {
@@ -44,7 +45,7 @@ public class GlobalExceptionHandler {
             .message(errorCode.getMessage())
             .build();
 
-        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(errorResponse));
     }
 
     private ErrorResponse makeErrorResponse(BindException ex) {

--- a/src/main/java/com/odiga/menu/api/OwnerCategoryApi.java
+++ b/src/main/java/com/odiga/menu/api/OwnerCategoryApi.java
@@ -19,14 +19,20 @@ public interface OwnerCategoryApi {
         @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 생성 성공", value = """
                 {
-                  "categoryId": 1,
-                  "categoryName": "카테고리"
+                    "success": true,
+                    "data": {
+                        "categoryId": 1,
+                        "categoryName": "카테고리"
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 생성 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> addCategory(@AuthenticationPrincipal Owner owner,
@@ -36,21 +42,27 @@ public interface OwnerCategoryApi {
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 조회 성공", value = """
-                [
-                    {
-                      "categoryId": 1,
-                      "categoryName": "카테고리"
-                    },
-                    {
-                      "categoryId": 2,
-                      "categoryName": "카테고리2"
-                    }
-                ]
+                {
+                    "success": true,
+                    "data": [
+                        {
+                          "categoryId": 1,
+                          "categoryName": "카테고리"
+                        },
+                        {
+                          "categoryId": 2,
+                          "categoryName": "카테고리2"
+                        }
+                    ]
+                }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 조회 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> findAllCategoryByStoreId(@PathVariable Long storeId);
@@ -60,13 +72,19 @@ public interface OwnerCategoryApi {
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "카테고리 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 카테고리 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 카테고리 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> deleteCategoryByCategoryId(@AuthenticationPrincipal Owner owner,

--- a/src/main/java/com/odiga/menu/api/OwnerMenuApi.java
+++ b/src/main/java/com/odiga/menu/api/OwnerMenuApi.java
@@ -18,16 +18,22 @@ public interface OwnerMenuApi {
         @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "메뉴 생성 성공", value = """
                 {
-                  "menuId": 1,
-                  "menuId": "메뉴",
-                  "price" : 10000,
-                  "imageUrl" : "https://example.com/image.jpg"
+                    "success": true,
+                     "data": {
+                          "menuId": 1,
+                          "menuName": "메뉴",
+                          "price" : 10000,
+                          "imageUrl" : "https://example.com/image.jpg"
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "메뉴 생성 실패", value = """
                 {
-                  "message": "존재하지 않는 카테고리 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 카테고리 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> saveMenu(@PathVariable Long categoryId,
@@ -37,25 +43,31 @@ public interface OwnerMenuApi {
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "메뉴 조회 성공", value = """
-                [
-                    {
-                      "menuId": 1,
-                      "menuId": "메뉴",
-                      "price" : 10000,
-                      "imageUrl" : "https://example.com/image.jpg"
-                    },
-                    {
-                      "menuId": 2,
-                      "menuId": "메뉴2",
-                      "price" : 20000,
-                      "imageUrl" : "https://example.com/image2.jpg"
-                    }
-                ]
+                {
+                    "success": true,
+                     "data": [
+                        {
+                          "menuId": 1,
+                          "menuName": "메뉴",
+                          "price" : 10000,
+                          "imageUrl" : "https://example.com/image.jpg"
+                        },
+                        {
+                          "menuId": 2,
+                          "menuName": "메뉴2",
+                          "price" : 20000,
+                          "imageUrl" : "https://example.com/image2.jpg"
+                        }
+                    ]
+                }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "메뉴 조회 실패", value = """
                 {
-                  "message": "존재하지 않는 카테고리 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 카테고리 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> findMenuByCategoryId(@PathVariable Long categoryId);
@@ -65,7 +77,10 @@ public interface OwnerMenuApi {
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "메뉴 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 메뉴 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 메뉴 입니다."
+                    }
                 }
                 """),})),})
     ResponseEntity<?> deleteMenuById(@PathVariable Long categoryId,

--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -57,6 +57,7 @@ public class OwnerCategoryService {
 
         store.validateOwner(owner.getId());
 
+        // TODO : category pk를 fk로 가지고 있는 menu의 cascade 전략 필요
         Category category = categoryRepository.findById(categoryId)
             .orElseThrow(() -> new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/com/odiga/menu/controller/OwnerCategoryController.java
+++ b/src/main/java/com/odiga/menu/controller/OwnerCategoryController.java
@@ -1,5 +1,6 @@
 package com.odiga.menu.controller;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.menu.api.OwnerCategoryApi;
 import com.odiga.menu.application.OwnerCategoryService;
 import com.odiga.menu.dto.CategoryCreateDto;
@@ -29,12 +30,12 @@ public class OwnerCategoryController implements OwnerCategoryApi {
                                          @PathVariable Long storeId,
                                          @Valid @RequestBody CategoryCreateDto categoryCreateDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerCategoryService.saveCategoryByStoreId(owner, storeId, categoryCreateDto));
+            .body(ApiResponse.ok(ownerCategoryService.saveCategoryByStoreId(owner, storeId, categoryCreateDto)));
     }
 
     @GetMapping
     public ResponseEntity<?> findAllCategoryByStoreId(@PathVariable Long storeId) {
-        return ResponseEntity.ok(ownerCategoryService.findAllCategoryByStoreId(storeId));
+        return ResponseEntity.ok(ApiResponse.ok(ownerCategoryService.findAllCategoryByStoreId(storeId)));
     }
 
     @DeleteMapping("{categoryId}")

--- a/src/main/java/com/odiga/menu/controller/OwnerMenuController.java
+++ b/src/main/java/com/odiga/menu/controller/OwnerMenuController.java
@@ -1,5 +1,6 @@
 package com.odiga.menu.controller;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.menu.api.OwnerMenuApi;
 import com.odiga.menu.application.OwnerMenuService;
 import com.odiga.menu.dto.MenuCreateDto;
@@ -20,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("api/v1/owners/categories/{categoryId}/menus")
 @RequiredArgsConstructor
-public class OwnerMenusController implements OwnerMenuApi {
+public class OwnerMenuController implements OwnerMenuApi {
 
     private final OwnerMenuService ownerMenuService;
 
@@ -29,12 +30,12 @@ public class OwnerMenusController implements OwnerMenuApi {
                                       @RequestPart MultipartFile menuImage,
                                       @Valid @RequestPart MenuCreateDto menuCreateDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerMenuService.addMenu(categoryId, menuImage, menuCreateDto));
+            .body(ApiResponse.ok(ownerMenuService.addMenu(categoryId, menuImage, menuCreateDto)));
     }
 
     @GetMapping
     public ResponseEntity<?> findMenuByCategoryId(@PathVariable Long categoryId) {
-        return ResponseEntity.ok(ownerMenuService.findMenuByCategoryId(categoryId));
+        return ResponseEntity.ok(ApiResponse.ok(ownerMenuService.findMenuByCategoryId(categoryId)));
     }
 
     @DeleteMapping("{menuId}")

--- a/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
+++ b/src/main/java/com/odiga/owner/api/OwnerAuthApi.java
@@ -17,15 +17,21 @@ public interface OwnerAuthApi {
         @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "회원가입 성공", value = """
                 {
-                  "id": 1,
-                  "email": "example@gmail.com",
-                  "name": "홍길동"
+                  "success": true,
+                  "data": {
+                    "id": 1,
+                    "email": "example@gmail.com",
+                    "name": "홍길동"
+                  }
                 }
                 """),})),
         @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "회원가입 실패 - 이미 존재하는 email", value = """
                 {
-                  "message": "이미 존재하는 email 입니다."
+                  "success": false,
+                  "error": {
+                    "message": "이미 존재하는 email 입니다."
+                  }
                 }
                 """)}))})
     ResponseEntity<?> ownerSignup(@RequestBody OwnerSignupRequestDto ownerSignupRequestDto);
@@ -34,20 +40,29 @@ public interface OwnerAuthApi {
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "로그인 성공", value = """
                 {
-                  "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQGdtYWlsLmNvbSIsImV4cCI6MTc0MjkxNDQ5Mn0.xBpNreQDdR_595Ap1oTDmUmJXCKB-HATRyvtUSUC-jwQVcI-ZmoG9wpi8y4xJOzIi00m2yKIkvsmNzkOeOf9DQ",
-                  "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQGdtYWlsLmNvbSIsImV4cCI6MTc0MjkxNzA0MH0.CTP03FkIwQ53jyBezXEM4pxtQoiBtoglW-3Da0q65xoa-Qzjvsqw5q9Pp31e2SJ_xtEzbkCLOh6qqkpBy0BakQ"
+                  "success": true,
+                  "data": {
+                    "accessToken": "accessTokenExample",
+                    "refreshToken": "refreshTokenExample"
+                  }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "로그인 실패 - 존재하지 않는 email", value = """
                 {
-                  "message": "존재하지 않는 계정입니다."
+                  "success": false,
+                  "error": {
+                    "message": "존재하지 않는 계정입니다."
+                  }
                 }
                 """),})),
         @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "로그인 실패 - 옳바르지 않은 비밀번호", value = """
                 {
-                  "message": "올바르지 않은 비밀번호 입니다."
+                  "success": false,
+                  "error": {
+                    "message": "올바르지 않은 비밀번호 입니다."
+                  }
                 }
                 """)}))})
     ResponseEntity<?> ownerLogin(@RequestBody OwnerLoginRequestDto ownerLoginRequestDto);

--- a/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
+++ b/src/main/java/com/odiga/owner/controller/OwnerAuthController.java
@@ -1,5 +1,6 @@
 package com.odiga.owner.controller;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.owner.api.OwnerAuthApi;
 import com.odiga.owner.application.OwnerAuthService;
 import com.odiga.owner.dto.OwnerLoginRequestDto;
@@ -23,14 +24,14 @@ public class OwnerAuthController implements OwnerAuthApi {
     @PostMapping("signup")
     public ResponseEntity<?> ownerSignup(@Valid @RequestBody OwnerSignupRequestDto ownerSignupRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerAuthService.signupOwner(ownerSignupRequestDto));
+            .body(ApiResponse.ok(ownerAuthService.signupOwner(ownerSignupRequestDto)));
     }
 
 
     @PostMapping("login")
     public ResponseEntity<?> ownerLogin(@Valid @RequestBody OwnerLoginRequestDto ownerLoginRequestDto) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ownerAuthService.loginOwner(ownerLoginRequestDto));
+            .body(ApiResponse.ok(ownerAuthService.loginOwner(ownerLoginRequestDto)));
     }
 
 }

--- a/src/main/java/com/odiga/reservation/api/OwnerReservationSlotApi.java
+++ b/src/main/java/com/odiga/reservation/api/OwnerReservationSlotApi.java
@@ -21,38 +21,44 @@ public interface OwnerReservationSlotApi {
     @ApiResponses({
         @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 등록 성공", value = """
-                [
-                    {
-                        "reservationSlotId": 1,
-                        "reservationTime": "2025-04-30 20:10:00",
-                        "status": "AVAILABLE"
-                    },
-                    {
-                        "reservationSlotId": 2,
-                        "reservationTime": "2025-04-09 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 3,
-                        "reservationTime": "2025-04-23 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 4,
-                        "reservationTime": "2025-04-16 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 5,
-                        "reservationTime": "2025-04-02 20:10:00",
-                        "status": "AVAILABLE"
-                      }
-                ]
+                {
+                    "success": true,
+                    "data": [
+                        {
+                            "reservationSlotId": 1,
+                            "reservationTime": "2025-04-30 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 2,
+                            "reservationTime": "2025-04-09 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 3,
+                            "reservationTime": "2025-04-23 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 4,
+                            "reservationTime": "2025-04-16 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 5,
+                            "reservationTime": "2025-04-02 20:10:00",
+                            "status": "AVAILABLE"
+                        }
+                    ]
+                }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> addReservationSlot(@AuthenticationPrincipal Owner owner,
@@ -62,38 +68,44 @@ public interface OwnerReservationSlotApi {
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 조회 성공", value = """
-                [
-                    {
-                        "reservationSlotId": 1,
-                        "reservationTime": "2025-04-30 20:10:00",
-                        "status": "AVAILABLE"
-                    },
-                    {
-                        "reservationSlotId": 2,
-                        "reservationTime": "2025-04-09 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 3,
-                        "reservationTime": "2025-04-23 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 4,
-                        "reservationTime": "2025-04-16 20:10:00",
-                        "status": "AVAILABLE"
-                      },
-                      {
-                        "reservationSlotId": 5,
-                        "reservationTime": "2025-04-02 20:10:00",
-                        "status": "AVAILABLE"
-                      }
-                ]
+                {
+                    "success": true,
+                    "data": [
+                        {
+                            "reservationSlotId": 1,
+                            "reservationTime": "2025-04-30 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 2,
+                            "reservationTime": "2025-04-09 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 3,
+                            "reservationTime": "2025-04-23 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 4,
+                            "reservationTime": "2025-04-16 20:10:00",
+                            "status": "AVAILABLE"
+                        },
+                        {
+                            "reservationSlotId": 5,
+                            "reservationTime": "2025-04-02 20:10:00",
+                            "status": "AVAILABLE"
+                        }
+                    ]
+                }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 조회 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> findBetweenDate(@AuthenticationPrincipal Owner owner,
@@ -106,13 +118,19 @@ public interface OwnerReservationSlotApi {
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 예약 슬롯 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 예약슬롯 입니다."
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),})),})
     ResponseEntity<?> deleteReservationSlot(@AuthenticationPrincipal Owner owner,
@@ -123,21 +141,30 @@ public interface OwnerReservationSlotApi {
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 상태 변경 성공", value = """
                 {
-                    "reservationSlotId": 1,
-                    "reservationTime": "2025-04-30 20:10:00",
-                    "status": "UNAVAILABLE"
+                    "success": false,
+                    "data": {
+                        "reservationSlotId": 1,
+                        "reservationTime": "2025-04-30 20:10:00",
+                        "status": "UNAVAILABLE"
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 예약 슬롯 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 예약슬롯 입니다."
+                    }
                 }
                 """),})),
         @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "예약 슬롯 삭제 실패", value = """
                 {
-                  "message": "존재하지 않는 가게 입니다."
+                    "success": false,
+                    "error": {
+                        "message": "존재하지 않는 가게 입니다."
+                    }
                 }
                 """),}))})
     ResponseEntity<?> changeStatusSlot(@AuthenticationPrincipal Owner owner,

--- a/src/main/java/com/odiga/reservation/application/OwnerReservationSlotService.java
+++ b/src/main/java/com/odiga/reservation/application/OwnerReservationSlotService.java
@@ -75,19 +75,20 @@ public class OwnerReservationSlotService {
             }
         }
 
-        List<ReservationSlot> result = new ArrayList<>();
+        List<ReservationSlot> saveList = new ArrayList<>();
         for (LocalDateTime dateTime : times) {
             ReservationSlot reservationSlot = ReservationSlot.builder()
                 .reservationTime(dateTime)
                 .store(store)
                 .build();
 
-            result.add(reservationSlot);
+            saveList.add(reservationSlot);
             store.addReservationSlot(reservationSlot);
         }
 
-        reservationSlotRepository.saveAllBatch(result);
+        reservationSlotRepository.saveAllBatch(saveList);
 
+        List<ReservationSlot> result = reservationSlotRepository.findByStoreIdAndBetweenReservationTime(storeId, startDate, endDate);
         return result.stream().map(ReservationSlotInfoDto::from).toList();
     }
 

--- a/src/main/java/com/odiga/reservation/controller/OwnerReservationSlotController.java
+++ b/src/main/java/com/odiga/reservation/controller/OwnerReservationSlotController.java
@@ -1,5 +1,6 @@
 package com.odiga.reservation.controller;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.owner.entity.Owner;
 import com.odiga.reservation.api.OwnerReservationSlotApi;
 import com.odiga.reservation.application.OwnerReservationSlotService;
@@ -33,7 +34,7 @@ public class OwnerReservationSlotController implements OwnerReservationSlotApi {
                                                 @PathVariable Long storeId,
                                                 @Valid @RequestBody ReservationSlotCreateRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerReservationSlotService.addAvailableReservationTime(owner, storeId, requestDto));
+            .body(ApiResponse.ok(ownerReservationSlotService.addAvailableReservationTime(owner, storeId, requestDto)));
     }
 
     @GetMapping
@@ -42,7 +43,7 @@ public class OwnerReservationSlotController implements OwnerReservationSlotApi {
                                              @RequestParam LocalDate startDate,
                                              @RequestParam LocalDate endDate) {
         return ResponseEntity.ok()
-            .body(ownerReservationSlotService.findByStoreIdAndBetweenReservationTime(owner, storeId, startDate, endDate));
+            .body(ApiResponse.ok(ownerReservationSlotService.findByStoreIdAndBetweenReservationTime(owner, storeId, startDate, endDate)));
     }
 
     @DeleteMapping("{reservationSlotId}")
@@ -59,6 +60,6 @@ public class OwnerReservationSlotController implements OwnerReservationSlotApi {
                                               @PathVariable Long reservationSlotId,
                                               @RequestBody ReservationSlotChangeStatusRequestDto requestDto) {
         return ResponseEntity.ok()
-            .body(ownerReservationSlotService.changeStatusById(owner, storeId, reservationSlotId, requestDto));
+            .body(ApiResponse.ok(ownerReservationSlotService.changeStatusById(owner, storeId, reservationSlotId, requestDto)));
     }
 }

--- a/src/main/java/com/odiga/store/api/OwnerStoreApi.java
+++ b/src/main/java/com/odiga/store/api/OwnerStoreApi.java
@@ -23,12 +23,15 @@ public interface OwnerStoreApi {
         @ApiResponse(responseCode = "201", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "가게 등록 성공", value = """
                 {
-                  "storeId": 1,
-                  "name": "가게 이름",
-                  "phoneNumber": "02-0000-0000",
-                  "address": "경상북도 경산시 대학로",
-                  "titleImageUrl": "https://example.com/image.jpg",
-                  "storeStatus": "ClOSE"
+                    "success": true,
+                    "data": {
+                      "storeId": 1,
+                      "name": "가게 이름",
+                      "phoneNumber": "02-0000-0000",
+                      "address": "경상북도 경산시 대학로",
+                      "titleImageUrl": "https://example.com/image.jpg",
+                      "storeStatus": "ClOSE"
+                    }
                 }
                 """),})),})
     ResponseEntity<?> registerOwnerStore(@AuthenticationPrincipal Owner owner,
@@ -39,32 +42,36 @@ public interface OwnerStoreApi {
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "가게 조회 성공", value = """
-                [
-                    {
-                      "storeId": 1,
-                      "name": "가게 이름",
-                      "phoneNumber": "02-0000-0000",
-                      "address": "경상북도 경산시 대학로",
-                      "titleImageUrl": "https://example.com/image.jpg",
-                      "storeStatus": "ClOSE"
-                    },
-                    {
-                      "storeId": 2,
-                      "name": "가게 이름2",
-                      "phoneNumber": "02-0000-0000",
-                      "address": "경상북도 경산시 대학로",
-                      "titleImageUrl": "https://example.com/image.jpg",
-                      "storeStatus": "ClOSE"
-                    }
-                ]
+                {
+                    "success": true,
+                    "data": [
+                        {
+                          "storeId": 1,
+                          "name": "가게 이름",
+                          "phoneNumber": "02-0000-0000",
+                          "address": "경상북도 경산시 대학로",
+                          "titleImageUrl": "https://example.com/image.jpg",
+                          "storeStatus": "ClOSE"
+                        },
+                        {
+                          "storeId": 2,
+                          "name": "가게 이름2",
+                          "phoneNumber": "02-0000-0000",
+                          "address": "경상북도 경산시 대학로",
+                          "titleImageUrl": "https://example.com/image.jpg",
+                          "storeStatus": "ClOSE"
+                        }
+                    ]
+                }
                 """),})),})
     ResponseEntity<?> findAllOwnerStore(@AuthenticationPrincipal Owner owner, Pageable pageable);
 
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "가게 상태 변경 성공", value = """
-                [
-                    {
+                {
+                    "success": true,
+                    "data": {
                       "storeId": 1,
                       "name": "가게 이름",
                       "phoneNumber": "02-0000-0000",
@@ -72,15 +79,16 @@ public interface OwnerStoreApi {
                       "titleImageUrl": "https://example.com/image.jpg",
                       "storeStatus": "OPEN"
                     }
-                ]
+                }
                 """),})),})
     ResponseEntity<?> changeStoreStatusToOpen(@AuthenticationPrincipal Owner owner, @PathVariable Long storeId);
 
     @ApiResponses({
         @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "가게 상태 변경 성공", value = """
-                [
-                    {
+                {
+                    "success": true,
+                    "data": {
                       "storeId": 1,
                       "name": "가게 이름",
                       "phoneNumber": "02-0000-0000",
@@ -88,7 +96,7 @@ public interface OwnerStoreApi {
                       "titleImageUrl": "https://example.com/image.jpg",
                       "storeStatus": "CLOSE"
                     }
-                ]
+                }
                 """),})),})
     ResponseEntity<?> changeStoreStatusToClose(@AuthenticationPrincipal Owner owner, @PathVariable Long storeId);
 }

--- a/src/main/java/com/odiga/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/odiga/store/controller/OwnerStoreController.java
@@ -1,5 +1,6 @@
 package com.odiga.store.controller;
 
+import com.odiga.common.dto.ApiResponse;
 import com.odiga.owner.entity.Owner;
 import com.odiga.store.api.OwnerStoreApi;
 import com.odiga.store.application.OwnerStoreService;
@@ -36,25 +37,25 @@ public class OwnerStoreController implements OwnerStoreApi {
                                                 @RequestPart List<MultipartFile> images) {
 
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ownerStoreService.registerStore(owner, storeRegisterRequestDto, storeTitleImage, images));
+            .body(ApiResponse.ok(ownerStoreService.registerStore(owner, storeRegisterRequestDto, storeTitleImage, images)));
 
     }
 
     @GetMapping
     public ResponseEntity<?> findAllOwnerStore(@AuthenticationPrincipal Owner owner, Pageable pageable) {
-        return ResponseEntity.ok(ownerStoreService.findAllStoreByOwner(owner, pageable));
+        return ResponseEntity.ok(ApiResponse.ok(ownerStoreService.findAllStoreByOwner(owner, pageable)));
     }
 
     @PutMapping("{storeId}/open")
     public ResponseEntity<?> changeStoreStatusToOpen(@AuthenticationPrincipal Owner owner,
                                                      @PathVariable Long storeId) {
-        return ResponseEntity.ok(ownerStoreService.openStore(owner, storeId));
+        return ResponseEntity.ok(ApiResponse.ok(ownerStoreService.openStore(owner, storeId)));
     }
 
     @PutMapping("{storeId}/close")
     public ResponseEntity<?> changeStoreStatusToClose(@AuthenticationPrincipal Owner owner,
                                                       @PathVariable Long storeId) {
-        return ResponseEntity.ok(ownerStoreService.closeStore(owner, storeId));
+        return ResponseEntity.ok(ApiResponse.ok(ownerStoreService.closeStore(owner, storeId)));
     }
 
 }

--- a/src/test/java/com/odiga/reservation/application/OwnerReservationServiceTest.java
+++ b/src/test/java/com/odiga/reservation/application/OwnerReservationServiceTest.java
@@ -1,6 +1,7 @@
 package com.odiga.reservation.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,9 +63,10 @@ class OwnerReservationServiceTest {
             new DaySchedule(WeekDay.MONDAY, LocalTime.of(9, 0), LocalTime.of(9, 30), 30);
 
         ReservationSlotCreateRequestDto requestDto = new ReservationSlotCreateRequestDto(2025, 4, List.of(daySchedule));
-        List<ReservationSlotInfoDto> result = ownerReservationSlotService.addAvailableReservationTime(owner, storeId, requestDto);
 
-        assertThat(result.size()).isEqualTo(8);
+        ownerReservationSlotService.addAvailableReservationTime(owner, storeId, requestDto);
+
+        verify(reservationSlotRepository).saveAllBatch(anyList());
     }
 
     @Test


### PR DESCRIPTION
### Summary

- 공통 포맷 API response 구현
- 공통 포맷 API response에 대한 swagger 문서 변경

### Technical issue

- `@ControllerAdvice`로 모든 response에 대해서 ApiResponse객체로 변환에 대한 고민
  - 각 response에 대한 Http status를 유연하게 응답하기 힘들다 판단하여 controller layer에서 ApiResponse로 직접 변환해 응답


### To Do

- 1:N 연관관계를 가지고 있는 테이블에서 1인 테이블의 row를 삭제 했을때 n인 테이블에 대해서 외래키 예외상황 발생
   - 해당 상황에 대해서 cascade 관련 정책 구현 필요  
- Reservation Slot 저장 로직 리팩토링 필요
  - Jdbc batchUpdate를 이용하는 insert에서 insert 한 data들의 pk를 바로 얻을수 없어서 재조회 후 pk를 응답 하는 방식 사용
  - 저장 하는 로직과 조회 하는 로직 분리가 필요해 보임