### PR TITLE
feat : category, menu 관계 cascade 설정

### DIFF
--- a/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
+++ b/src/main/java/com/odiga/menu/application/OwnerCategoryService.java
@@ -57,7 +57,6 @@ public class OwnerCategoryService {
 
         store.validateOwner(owner.getId());
 
-        // TODO : category pk를 fk로 가지고 있는 menu의 cascade 전략 필요
         Category category = categoryRepository.findById(categoryId)
             .orElseThrow(() -> new CustomException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/com/odiga/menu/entity/Category.java
+++ b/src/main/java/com/odiga/menu/entity/Category.java
@@ -2,6 +2,7 @@ package com.odiga.menu.entity;
 
 import com.odiga.common.entity.BaseEntity;
 import com.odiga.store.entity.Store;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,7 +35,7 @@ public class Category extends BaseEntity {
     private Store store;
 
     @Builder.Default
-    @OneToMany(mappedBy = "category")
+    @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
     private List<Menu> menus = new ArrayList<>();
 
     public void addMenu(Menu menu) {

--- a/src/test/java/com/odiga/menu/dao/MenuRepositoryTest.java
+++ b/src/test/java/com/odiga/menu/dao/MenuRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.odiga.menu.dao;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.odiga.global.config.JpaConfig;
+import com.odiga.global.exception.CustomException;
+import com.odiga.menu.entity.Category;
+import com.odiga.menu.entity.Menu;
+import com.odiga.menu.exception.MenuErrorCode;
+import com.odiga.owner.dao.OwnerRepository;
+import com.odiga.owner.entity.Owner;
+import com.odiga.store.dao.StoreRepository;
+import com.odiga.store.entity.Store;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@DataJpaTest
+class MenuRepositoryTest {
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    OwnerRepository ownerRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    Category category;
+
+    @BeforeEach
+    void init() {
+        Owner owner = Owner.builder()
+            .email("example@google.com")
+            .build();
+
+        ownerRepository.save(owner);
+
+        Store store = Store.builder()
+            .name("store")
+            .owner(owner)
+            .build();
+
+        storeRepository.save(store);
+
+        category = Category.builder()
+            .name("category")
+            .store(store)
+            .build();
+
+        categoryRepository.save(category);
+    }
+
+    @Test
+    void cascadeDeleteTest() {
+        Menu menu1 = Menu.builder()
+            .name("menu1")
+            .build();
+
+        Menu menu2 = Menu.builder()
+            .name("menu1")
+            .build();
+
+        category.addMenu(menu1);
+        category.addMenu(menu2);
+
+        menuRepository.saveAll(List.of(menu1, menu2));
+
+        categoryRepository.delete(category);
+        entityManager.flush();
+
+        assertThatThrownBy(() -> menuRepository.findById(menu1.getId())
+            .orElseThrow(() -> new CustomException(MenuErrorCode.NOT_FOUND_MENU)))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", MenuErrorCode.NOT_FOUND_MENU);
+
+        assertThatThrownBy(() -> menuRepository.findById(menu2.getId())
+            .orElseThrow(() -> new CustomException(MenuErrorCode.NOT_FOUND_MENU)))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", MenuErrorCode.NOT_FOUND_MENU);
+    }
+}


### PR DESCRIPTION
### Summary

- category, menu 관계 cascade 설정
- 다른 1:N 관계를 가지고 있는 테이블들의 cascade도 설정 하려고 했지만 다른 테이블들은 삭제에 대한 구체화가 필요하다고 생각하여 명확히 삭제에 대한 구체화가 있는 category, menu 테이블에 대한 cascade 설정만 진행함

### Technical issue

- `@OneToMany(cascade = CascadeType.REMOVE)`와 `@OnDelete`
  - `@OneToMany(cascade = CascadeType.REMOVE)`는 JPA에 의해 처리되어 JPA에 의해 외래 키를 찾아가며 참조하는 레코드를 제거한다.
  - `@OnDelete`는 프로그램 올라오기 전에 DB 테이블에 접근해 ON DELETE CASCADE를 붙여주는것
  - JPA 가 DDL을 날리는것을 지양해야한다고 생각해 `@OneToMany(cascade = CascadeType.REMOVE)` 적용

### To Do

- [가게 테이블 관련 기능구현](https://github.com/O-DI-GA/odiga-was-refactoring/issues/12)